### PR TITLE
Updates RPKManager configuration dictionary to use modern keys

### DIFF
--- a/ProximityKitReference/ViewController.swift
+++ b/ProximityKitReference/ViewController.swift
@@ -20,7 +20,7 @@ class ViewController: UIViewController, RPKManagerDelegate {
     // WARNING: Use the values from your kit in the configuration
     
     let configDict: [String:Any] = [
-      "api_token": "c0de", // <Kit Token from Settings>
+      "api_token": "0000000000000000000000000000000000000000000000000000000000000000", // <Kit Token from Settings>
       "kit_url": "https://proximitykit.radiusnetworks.com/api/kits/0" // Kit URL from Settings, e. g. https://proximitykit.radiusnetworks.com/api/kits/[number]
     ]
 

--- a/ProximityKitReference/ViewController.swift
+++ b/ProximityKitReference/ViewController.swift
@@ -20,12 +20,8 @@ class ViewController: UIViewController, RPKManagerDelegate {
     // WARNING: Use the values from your kit in the configuration
     
     let configDict: [String:Any] = [
-      "PKAPIToken": "0000000000000000000000000000000000000000000000000000000000000000",
-      "PKGlobalUserIdentifier": 00000,
-      "PKKitName": "[ck_0000] Not a Real Kit",
-      "PKKitURL": "https://proximitykit.radiusnetworks.com/api/kits/0000",
-      "PKUserEmail": "example@example.com",
-      "PKUserIdentifier": 0000
+      "api_token": "c0de", // <Kit Token from Settings>
+      "kit_url": "https://proximitykit.radiusnetworks.com/api/kits/0" // Kit URL from Settings, e. g. https://proximitykit.radiusnetworks.com/api/kits/[number]
     ]
 
     self.proximityKitManager = RPKManager(delegate:self, andConfig:configDict)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# Proximity Kit Example Applicaiton
+# Proximity Kit Example Application
 
-A bare-bones example on how to use the Proximity Kit SDK for iOS.
+A bare-bones example of how to use the Proximity Kit SDK for iOS.
+
+In order to run this app, you need a valid kit. Make sure you use your own Kit Token and Kit URL in the configuration dictionary used when creating an `RPKManager` in the file `ViewController.swift`. You can find the token and URL on the Settings page for your kit.  
+
+If the app crashes with `uncaught exception 'Invalid ProximityKit Configuration'`, chances are you are not using a correct Kit Token and/or Kit URL.
 
 For more information please visit [proximitykit.radiusnetworks.com](http://proximitykit.radiusnetworks.com/)
-


### PR DESCRIPTION
Aligns code creating the configuration dictionary in the example app
with documentation, e. g. `api_token` and `kit_url` instead of `PKAPIToken` and `PKKitURL`.
Also updates `README.md` to suggest using the user's PK Kit URL and
Token values.
I'm a little bummed that, out of the box, the app simply crashes. But
absent `#warning` in Objective C, my only other recourse would be to
catch the `Invalid ProximityKit Configuration` Objective C exception in Swift.  But that'd pollute the code
base with some ugly Objective C code that would no longer be needed
once the user sets up the configuration properly.
So... here we are.